### PR TITLE
Use arm64 terraform on arm64 Mac OS

### DIFF
--- a/toolchains/terraform/toolchain.bzl
+++ b/toolchains/terraform/toolchain.bzl
@@ -15,8 +15,10 @@ def get_dependencies(version):
 def _detect_platform_arch(ctx):
     if ctx.os.name == "linux":
         platform, arch = "linux", "amd64"
-    elif ctx.os.name == "mac os x":
+    elif ctx.os.name == "mac os x" and ctx.os.arch == "amd64":
         platform, arch = "darwin", "amd64"
+    elif ctx.os.name == "mac os x" and ctx.os.arch == "aarch64":
+        platform, arch = "darwin", "arm64"
     else:
         fail("Unsupported operating system: " + ctx.os.name)
 


### PR DESCRIPTION
While the terraform_provider rule downloads providers for the arm64 architecture, the register_terraform_version repository rule does not. Let's fix this.

This also has the effect of making any terraform providers that aren't loaded via terraform_provider rules (and instead as required_provider blocks) use arm64 instead of amd64.

Tested by changing a Bazel WORKSPACE to point to my change and running terraform in debug mode to see it uses arm64.